### PR TITLE
Fix:Updated the WPM calculation logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,13 +88,20 @@ export default function App() {
 
     setInput(newValue);
   };
-
+  
+//Updated the WPM calculation logic to ensure accurate calculation based on the time taken and word count. Fixed issues with startTime and endTime initialization and ensured proper state updates for calculating WPM.
   const calculateWPM = () => {
     if (!startTime || !endTime) return 0;
-    const timeTaken = (endTime - startTime) / 60000;
-    const wordCount = currentText.split(" ").length;
-    return (wordCount / timeTaken).toFixed(2);
+  const timeTaken = (endTime - startTime) / 60000;
+  const wordCount = input.trim().match(/\S+/g)?.length || 0;
+  return (wordCount / timeTaken).toFixed(0);
   };
+  
+  useEffect(() => {
+    if (isCompleted) {
+      setEndTime(Date.now()); // Set endTime when typing is completed
+    }
+  }, [isCompleted]);
 
   const calculatePoints = (mistakes: number) => {
     const textLength = currentText.replace(/\s/g, "").length;
@@ -211,3 +218,4 @@ export default function App() {
     </div>
   );
 }
+


### PR DESCRIPTION
This pull request addresses an issue where the displayed Words Per Minute (WPM) was erroneously showing as 0, failing to reflect the actual typing speed. The problem stemmed from incorrect initialization of startTime and endTime variables and inadequate state updates for WPM calculation.

To resolve this issue, I've implemented crucial updates to the WPM calculation logic. This includes ensuring proper initialization of startTime and endTime variables, correcting the calculation process based on the time taken and word count, and ensuring accurate state updates to reflect the calculated WPM.

With these changes, the WPM display now accurately reflects the user's typing speed

Before Changes:![Before](https://github.com/mirayatech/TypeRush/assets/148910960/9631ad75-8f17-4761-af1c-68ef05c6d07e)
After Changes:![After](https://github.com/mirayatech/TypeRush/assets/148910960/5bafa744-509e-4154-bed9-0cca08540167)



